### PR TITLE
chore: refactor code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# deup
+# DEUP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deup",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deup",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "ISC",
       "dependencies": {
         "commander": "11.0.0",
@@ -16,10 +16,10 @@
         "shelljs": "0.8.5"
       },
       "bin": {
-        "deup": "deup.js"
+        "deup": "dist/src/deup.js"
       },
       "devDependencies": {
-        "@types/node": "^20.4.2",
+        "@types/node": "^20.4.4",
         "typescript": "^5.1.6"
       }
     },
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.4.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
-      "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw==",
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.4.tgz",
+      "integrity": "sha512-CukZhumInROvLq3+b5gLev+vgpsIqC2D0deQr/yS1WnxvmYLlJXZpaQrQiseMY+6xusl79E04UjWoqyr+t1/Ew==",
       "dev": true
     },
     "node_modules/ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "bin": {
-    "deup": "./dist/deup.js"
+    "deup": "./dist/src/deup.js"
   },
   "scripts": {
     "build": "tsc",
@@ -22,7 +22,7 @@
     "shelljs": "0.8.5"
   },
   "devDependencies": {
-    "@types/node": "^20.4.2",
+    "@types/node": "^20.4.4",
     "typescript": "^5.1.6"
   }
 }

--- a/src/deup.ts
+++ b/src/deup.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+import { program } from "commander"
+
+import packageJSON from "../package.json" assert { type: "json" }
+import { dedupe } from "./commands/dedupe.js"
+
+const main = async (): Promise<void> => {
+    program
+        .version(packageJSON.version)
+        .arguments("<packageName>")
+        .action(dedupe)
+    program.parse(process.argv)
+}
+void main()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,6 @@
     "sourceMap": true,
     "outDir": "dist"
   },
+  "include": ["src"],
   "lib": ["es2015"]
 }


### PR DESCRIPTION
- ✨ Moves the code to the src folder
- ✨ Splits the bin entry point and the dedupe function into separate files
- ✨ Moves from inserting the dependency in the json and sorting it to using the native npm install command
- 📦 Updates @types/node
- 🐛 Fixes a small bug that could happen in case a package-lock.json file did not exist